### PR TITLE
feat: add new Github workflows

### DIFF
--- a/.github/workflows/take-issue.yaml
+++ b/.github/workflows/take-issue.yaml
@@ -1,0 +1,20 @@
+# .github/workflows/take.yml
+name: Assign issue to contributor
+on:
+  issue_comment:
+
+jobs:
+  assign:
+    name: Take an issue
+    runs-on: ubuntu-latest
+    permissions:
+      issues: write
+    steps:
+      - name: take the issue
+        uses: bdougie/take-action@main
+        with:
+          message: Thanks for taking this issue! Let us know if you have any questions!
+          blockingLabels: in progress
+          blockingLabelsMessage: This issue is already taken by someone else and is in progress. You can find another one by surfing the issues page.
+          trigger: .take
+          token: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/welcome-contributors.yaml
+++ b/.github/workflows/welcome-contributors.yaml
@@ -1,0 +1,46 @@
+name: Welcome New Contributors
+
+on:
+  issues:
+    types: [opened]
+  pull_request_target:
+    types: [opened]
+
+jobs:
+  welcome:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Welcome Issue
+        if: github.event_name == 'issues'
+        uses: actions/github-script@v5
+        with:
+          script: |
+            const issue = context.issue;
+            const repo = context.repo;
+            const issueAuthor = context.payload.sender.login;
+            const welcomeMessage = `
+              Hi @${issueAuthor}! :wave:
+              Thank you for creating an issue in our repository! We appreciate your contribution and will get back to you as soon as possible.
+            `;
+            github.rest.issues.createComment({
+              ...repo,
+              issue_number: issue.number,
+              body: welcomeMessage
+            });
+      - name: Welcome Pull Request
+        if: github.event_name == 'pull_request_target'
+        uses: actions/github-script@v5
+        with:
+          script: |
+            const pr = context.issue;
+            const repo = context.repo;
+            const prAuthor = context.payload.sender.login;
+            const welcomeMessage = `
+              Hi @${prAuthor}! :wave:
+              Thank you for submitting a pull request! We appreciate your contribution and will review your changes as soon as possible.
+            `;
+            github.rest.issues.createComment({
+              ...repo,
+              issue_number: pr.number,
+              body: welcomeMessage
+            });

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -16,13 +16,13 @@ Some thoughts to help you contribute to this project
 ```sh
 $ git clone https://github.com/<your-name>/projectx
 $ cd projectx
-$ yarn install
+$ pnpm i
 ```
 
 ## Building
 
 ```sh
-$ yarn build
+$ pnpm run build
 ```
 
 ## Pull Requests
@@ -32,7 +32,7 @@ $ yarn build
 1. Fork the repo and create your branch
 2. Name your branch something that is descriptive to the work you are doing. i.e. adds-new-thing or fixes-mobile
 3. Make sure you address any lint warnings.
-4. Run yarn format if your unsure
+4. Run `pnpm run format` if your unsure
 5. If you make the existing code better, please let us know in your PR description.
 6. A PR description and title are required. The title is required to begin with: "feat:" or "fix:"
 7. [Link to an issue](https://help.github.com/en/github/writing-on-github/autolinked-references-and-urls) in the project. Unsolicited code is welcomed, but an issue is required for announce your intentions. PR's without a linked issue will be marked invalid and closed.


### PR DESCRIPTION
## Description
Add two new workflows. The first one to welcome new contributors and the second one to assign new issues to contributors autonomously by typing `.take` in a comment.

## What type of PR is this? (check all applicable)

- [x] 💡 Feature
- [ ] 🐛 Bug Fix
- [x] 📝 Documentation Update
- [ ] 🎨 Style
- [ ] 🧑‍💻 Code Refactor
- [ ] 🔥 Performance Improvements
- [ ] ✅ Test
- [ ] 🤖 Build
- [x] 🔁 CI
- [ ] 📦 Chore (Release)
- [ ] ⏩ Revert

## Related Tickets & Documents

## Mobile & Desktop Screenshots/Recordings

## Steps to QA

## Added to documentation?

## [optional] Are there any post-deployment tasks we need to perform?

You need to create a Github token and add it among the repository secrets. If you want we can do it together Chris @meglerhagen .
